### PR TITLE
Bugfix/content provider authority conflicts problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.mengdd.preferencesprovider:preferences-provider:0.1.0'
+    compile 'com.mengdd.preferencesprovider:preferences-provider:0.2.0'
 }
 
 ```

--- a/README.md
+++ b/README.md
@@ -19,6 +19,35 @@ dependencies {
 
 ```
 
+## Set Authority
+Library users must define their own authority for the content provider.
+
+This is done by defining the `preferences_provider_authority` string value:
+```
+resValue "string", "preferences_provider_authority", "${applicationId}.preferencesprovider"
+```
+For example:
+In your app's `build.gradle`
+```
+defaultConfig {
+    applicationId "com.ddmeng.preferencesprovider.sample"
+    minSdkVersion 14
+    targetSdkVersion 25
+    versionCode 1
+    versionName "1.0"
+    resValue "string", "preferences_provider_authority", "${applicationId}.preferencesprovider"
+}
+```
+
+This is because every content provider needs an unique authority.
+If multiple apps use the library but they have same authority for a content provider, only one app can be installed on a device.
+
+(See issue: https://github.com/mengdd/PreferencesProvider/issues/2).
+
+So the library enforce the client users override the authority. If the authority is not defined, an `IllegalStateException` will be thrown.
+An authority with **applicationId** is recommended.
+
+
 ## Usage
 ### 1. Create a module for your preferences.
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -37,7 +37,7 @@ ext {
     siteUrl = 'https://github.com/mengdd/PreferencesProvider'
     gitUrl = 'https://github.com/mengdd/PreferencesProvider'
 
-    libraryVersion = '0.1.0'
+    libraryVersion = '0.2.0'
 
     developerId = 'mengdd'
     developerName = 'Dandan Meng'

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -9,6 +9,8 @@ android {
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
+
+        resValue "string", "preferences_provider_authority", "com.ddmeng.preferencesprovider.provider"
     }
     buildTypes {
         debug {}

--- a/lib/src/main/AndroidManifest.xml
+++ b/lib/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
         android:supportsRtl="true">
         <provider
             android:name=".provider.PreferencesProvider"
-            android:authorities="com.ddmeng.preferencesprovider.provider"
+            android:authorities="@string/preferences_provider_authority"
             android:exported="false" />
     </application>
 

--- a/lib/src/main/java/com/ddmeng/preferencesprovider/provider/PreferencesProvider.java
+++ b/lib/src/main/java/com/ddmeng/preferencesprovider/provider/PreferencesProvider.java
@@ -36,8 +36,13 @@ public class PreferencesProvider extends BaseContentProvider {
         super.onCreate();
         String authority = getContext().getString(R.string.preferences_provider_authority);
         if (LIBRARY_DEFAULT_AUTHORITY.equals(authority)) {
-            throw new IllegalStateException("Please don't use the library's default authority for your app. " +
-                    "Multiple apps with the same authority will fail to install on the same device.");
+            throw new IllegalStateException("Please don't use the library's default authority for your app. \n " +
+                    "Multiple apps with the same authority will fail to install on the same device.\n " +
+                    "Please add the line: \n " +
+                    "==================================================================================================\n " +
+                    " resValue \"string\", \"preferences_provider_authority\", \"${applicationId}.preferencesprovider\" \n " +
+                    "==================================================================================================\n " +
+                    "in your build.gradle file");
         }
         setAuthority(authority);
         return true;

--- a/lib/src/main/java/com/ddmeng/preferencesprovider/provider/PreferencesProvider.java
+++ b/lib/src/main/java/com/ddmeng/preferencesprovider/provider/PreferencesProvider.java
@@ -1,7 +1,5 @@
 package com.ddmeng.preferencesprovider.provider;
 
-import java.util.Arrays;
-
 import android.content.ContentValues;
 import android.content.UriMatcher;
 import android.database.Cursor;
@@ -10,8 +8,11 @@ import android.net.Uri;
 import android.util.Log;
 
 import com.ddmeng.preferencesprovider.BuildConfig;
+import com.ddmeng.preferencesprovider.R;
 import com.ddmeng.preferencesprovider.provider.base.BaseContentProvider;
 import com.ddmeng.preferencesprovider.provider.preferences.PreferencesColumns;
+
+import java.util.Arrays;
 
 public class PreferencesProvider extends BaseContentProvider {
     private static final String TAG = PreferencesProvider.class.getSimpleName();
@@ -20,20 +21,33 @@ public class PreferencesProvider extends BaseContentProvider {
 
     private static final String TYPE_CURSOR_ITEM = "vnd.android.cursor.item/";
     private static final String TYPE_CURSOR_DIR = "vnd.android.cursor.dir/";
+    private static final String LIBRARY_DEFAULT_AUTHORITY = "com.ddmeng.preferencesprovider.provider";
 
-    public static final String AUTHORITY = "com.ddmeng.preferencesprovider.provider";
-    public static final String CONTENT_URI_BASE = "content://" + AUTHORITY;
+    public static String CONTENT_URI_BASE;
 
     private static final int URI_TYPE_PREFERENCES = 0;
     private static final int URI_TYPE_PREFERENCES_ID = 1;
 
 
-
     private static final UriMatcher URI_MATCHER = new UriMatcher(UriMatcher.NO_MATCH);
 
-    static {
-        URI_MATCHER.addURI(AUTHORITY, PreferencesColumns.TABLE_NAME, URI_TYPE_PREFERENCES);
-        URI_MATCHER.addURI(AUTHORITY, PreferencesColumns.TABLE_NAME + "/#", URI_TYPE_PREFERENCES_ID);
+    @Override
+    public boolean onCreate() {
+        super.onCreate();
+        String authority = getContext().getString(R.string.preferences_provider_authority);
+        if (LIBRARY_DEFAULT_AUTHORITY.equals(authority)) {
+            throw new IllegalStateException("Please don't use the library's default authority for your app. " +
+                    "Multiple apps with the same authority will fail to install on the same device.");
+        }
+        setAuthority(authority);
+        return true;
+    }
+
+    private static void setAuthority(String authority) {
+        URI_MATCHER.addURI(authority, PreferencesColumns.TABLE_NAME, URI_TYPE_PREFERENCES);
+        URI_MATCHER.addURI(authority, PreferencesColumns.TABLE_NAME + "/#", URI_TYPE_PREFERENCES_ID);
+        CONTENT_URI_BASE = "content://" + authority;
+
     }
 
     @Override
@@ -73,13 +87,15 @@ public class PreferencesProvider extends BaseContentProvider {
 
     @Override
     public int update(Uri uri, ContentValues values, String selection, String[] selectionArgs) {
-        if (DEBUG) Log.d(TAG, "update uri=" + uri + " values=" + values + " selection=" + selection + " selectionArgs=" + Arrays.toString(selectionArgs));
+        if (DEBUG)
+            Log.d(TAG, "update uri=" + uri + " values=" + values + " selection=" + selection + " selectionArgs=" + Arrays.toString(selectionArgs));
         return super.update(uri, values, selection, selectionArgs);
     }
 
     @Override
     public int delete(Uri uri, String selection, String[] selectionArgs) {
-        if (DEBUG) Log.d(TAG, "delete uri=" + uri + " selection=" + selection + " selectionArgs=" + Arrays.toString(selectionArgs));
+        if (DEBUG)
+            Log.d(TAG, "delete uri=" + uri + " selection=" + selection + " selectionArgs=" + Arrays.toString(selectionArgs));
         return super.delete(uri, selection, selectionArgs);
     }
 

--- a/lib/src/main/java/com/ddmeng/preferencesprovider/provider/base/BaseContentProvider.java
+++ b/lib/src/main/java/com/ddmeng/preferencesprovider/provider/base/BaseContentProvider.java
@@ -40,7 +40,7 @@ public abstract class BaseContentProvider extends ContentProvider {
     protected SQLiteOpenHelper mSqLiteOpenHelper;
 
     @Override
-    public final boolean onCreate() {
+    public boolean onCreate() {
         if (hasDebug()) {
             // Enable logging of SQL statements as they are executed.
             try {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -11,6 +11,7 @@ android {
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
+        resValue "string", "preferences_provider_authority", "${applicationId}.preferencesprovider"
     }
     buildTypes {
         release {


### PR DESCRIPTION
**Why**:
Issue: https://github.com/mengdd/PreferencesProvider/issues/2
Content provider has unique authority. If multiple apps use a content provider has the same authority, only one app can be installed onto device.

**Fix**:
define the authority string using gradle.
Client users have to define their own authority by override the string value.
So every app can define their own authority with applicationId.
 
If default authority is not override, an exception be will thrown.